### PR TITLE
Fix Brazilian Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,26 +1,27 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Brazilian Portuguese translation for Pins.
+# Copyright (C) 2025 THE PINS' COPYRIGHT HOLDER
 # This file is distributed under the same license as the pinapp package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# johnpeter19 <johnppetersa@gmail.com>, 2025.
+# Filipe Motta <luizfilipemotta@gmail.com>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: pinapp\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-23 22:42+0100\n"
-"PO-Revision-Date: 2025-02-19 08:49-0300\n"
-"Last-Translator: johnpeter19 <johnppetersa@gmail.com>\n"
-"Language-Team: \n"
+"PO-Revision-Date: 2025-03-26 02:44-0300\n"
+"Last-Translator: Filipe Motta <luizfilipemotta@gmail.com>\n"
+"Language-Team: Brazilian Portuguese\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Gtranslator 48.0\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
 
 #: data/io.github.fabrialberio.pinapp.desktop.in:3 src/pins-window.ui:14
 msgid "Pins"
-msgstr "Pinos"
+msgstr "Pins"
 
 #: data/io.github.fabrialberio.pinapp.desktop.in:4
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:9
@@ -29,13 +30,13 @@ msgstr "Crie e edite atalhos de aplicativos"
 
 #: data/io.github.fabrialberio.pinapp.desktop.in:11
 msgid "GNOME;GTK;Apps;Shortcuts;Icons;"
-msgstr "Gnome; gtk; apps; atalhos; ícones;"
+msgstr "GNOME;GTK;Apps;Aplicativos;Shortcuts;Atalhos;Icons;Ícones;"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:15
 msgid "Pins allows you to customize your app menu by editing .desktop files."
 msgstr ""
-"Pinos permitem que você personalize o menu do aplicativo editando arquivos ."
-"DESKTOP."
+"O Pins permite que você personalize o menu de aplicativos editando arquivos ."
+"desktop."
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:16
 msgid "Some of the things you can do are:"
@@ -47,59 +48,61 @@ msgstr "Alterar um ícone de aplicativo que não se encaixa no seu tema,"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:19
 msgid "creating custom shortcuts to websites,"
-msgstr "criando atalhos personalizados para sites,"
+msgstr "Criar atalhos personalizados para sites da web,"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:20
 msgid "hiding apps you don't want to see,"
-msgstr "escondendo aplicativos que você não quer ver,"
+msgstr "Ocultar aplicativos que você não quer ver,"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:21
 msgid "editing properties in .desktop files."
-msgstr "Editando propriedades nos arquivos .desktop."
+msgstr "Editar propriedades em arquivos .desktop."
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:32
 msgid "Screenshot of Pins showing the app grid"
-msgstr ""
+msgstr "Captura de tela do Pins mostrando a grade de aplicativos"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:37
 msgid "Screenshot of Pins showing an opened file"
-msgstr ""
+msgstr "Captura de tela do Pins mostrando um arquivo aberto"
 
 #: data/io.github.fabrialberio.pinapp.metainfo.xml.in:42
 msgid "Screenshot of Pins showing an opened file on a small screen"
 msgstr ""
+"Captura de tela do Pins mostrando um arquivo aberto em uma tela pequena"
 
 #: data/io.github.fabrialberio.pinapp.gschema.xml:6
 msgid "Show all apps"
-msgstr ""
+msgstr "Mostrar todos os aplicativos"
 
 #: data/io.github.fabrialberio.pinapp.gschema.xml:17
 msgid "List of desktop file search paths in order of priority"
 msgstr ""
+"Lista de caminhos para busca de arquivos .desktop, em ordem de prioridade"
 
 #: src/help-overlay.ui:11
 msgctxt "shortcut window"
 msgid "General"
-msgstr "Em geral"
+msgstr "Geral"
 
 #: src/help-overlay.ui:14
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
-msgstr "Mostre atalhos"
+msgstr "Mostrar atalhos"
 
 #: src/help-overlay.ui:20
 msgctxt "shortcut window"
 msgid "Quit"
-msgstr "Desistir"
+msgstr "Sair"
 
 #: src/help-overlay.ui:26
 msgctxt "shortcut window"
 msgid "Add new app"
-msgstr "Adicione novo aplicativo"
+msgstr "Adicionar novo aplicativo"
 
 #: src/pins-add-key-dialog.ui:4
 msgid "Add new key"
-msgstr "Adicione nova chave"
+msgstr "Adicionar nova chave"
 
 #: src/pins-add-key-dialog.ui:11
 msgid "Key"
@@ -115,7 +118,7 @@ msgstr "_Adicionar"
 
 #: src/pins-app-view.ui:15 src/pins-app-view.ui:97
 msgid "Add new app"
-msgstr "Adicione novo aplicativo"
+msgstr "Adicionar novo aplicativo"
 
 #: src/pins-app-view.ui:21
 msgid "Show menu"
@@ -123,7 +126,7 @@ msgstr "Mostrar menu"
 
 #: src/pins-app-view.ui:28
 msgid "Search"
-msgstr "Procurar"
+msgstr "Pesquisar"
 
 #: src/pins-app-view.ui:70
 msgid "Loading apps…"
@@ -135,19 +138,19 @@ msgstr "Nenhum aplicativo encontrado"
 
 #: src/pins-app-view.ui:116
 msgid "Show _all apps"
-msgstr ""
+msgstr "Mostrar _todos os aplicativos"
 
 #: src/pins-app-view.ui:122
 msgid "_Keyboard Shortcuts"
-msgstr "_Atalhos de teclado"
+msgstr "Atalhos de _teclado"
 
 #: src/pins-app-view.ui:126
 msgid "_About Pins"
-msgstr "_ Sobre os pinos"
+msgstr "_ Sobre o Pins"
 
 #: src/pins-file-view.ui:20
 msgid "Delete"
-msgstr "Deletar"
+msgstr "Excluir"
 
 #: src/pins-file-view.ui:64
 msgid "Edit icon"
@@ -155,15 +158,15 @@ msgstr "Editar ícone"
 
 #: src/pins-file-view.ui:86
 msgid "Load icon from file"
-msgstr "Carregue o ícone do arquivo"
+msgstr "Carregar ícone de um arquivo"
 
 #: src/pins-file-view.ui:131
 msgid "Autostart"
-msgstr "Autostart"
+msgstr "Início automático"
 
 #: src/pins-file-view.ui:134
 msgid "Launch this application on login"
-msgstr "Inicie este aplicativo no login"
+msgstr "Inicie este aplicativo ao fazer login"
 
 #: src/pins-file-view.ui:150
 msgid "Invisible"
@@ -171,11 +174,11 @@ msgstr "Invisível"
 
 #: src/pins-file-view.ui:153
 msgid "Hide this application in the app menu"
-msgstr "Ocultar este aplicativo no menu do aplicativo"
+msgstr "Ocultar este aplicativo no menu de aplicativos"
 
 #: src/pins-file-view.ui:185
 msgid "Add key"
-msgstr "Adicione a chave"
+msgstr "Adicionar chave"
 
 #: src/pins-key-row.ui:9
 msgid "Erase changes"
@@ -183,11 +186,11 @@ msgstr "Apagar mudanças"
 
 #: src/pins-key-row.ui:21
 msgid "Remove key"
-msgstr "Remova a chave"
+msgstr "Remover chave"
 
 #: src/pins-key-row.ui:32
 msgid "Select locale"
-msgstr "Selecione Locais"
+msgstr "Selecionar localidade"
 
 #: src/pins-file-view.c:362
 msgid "Load icon"


### PR DESCRIPTION
The pt_BR translation that was merged before was probably automated and not proofread.

I've reviewed it and fixed the mistakes and imprecisions.

Also, as a warning for this project and others: the author of the previous translation is spamming pull requests for many projects, sending automated and non-proofread pt_BR translations, which offer a poor experience for Brazilian Portuguese-speaking users.

I'm trying to fix as many translations as I can, but I can't keep up with his (automated) pace.