### PR TITLE
glib schema update to find share/applications on NixOS

### DIFF
--- a/data/io.github.fabrialberio.pinapp.gschema.xml
+++ b/data/io.github.fabrialberio.pinapp.gschema.xml
@@ -12,7 +12,8 @@
         "/var/lib/flatpak/exports/share",
         "~/.local/share/flatpak/exports/share",
         "~/.local/share/xdg-desktop-portal",
-        "/var/lib/snapd/desktop"
+        "/var/lib/snapd/desktop",
+        "/run/current-system/sw/share"
         ]</default>
       <summary>List of desktop file search paths in order of priority</summary>
     </key>


### PR DESCRIPTION
Added the path "/run/current-system/sw/share" to the default glib schema

#### Before:
![Screenshot From 2025-05-24 23-36-45](https://github.com/user-attachments/assets/429c9b2c-36b2-48dd-8ca7-bca3709aad57)
#### After:
![Screenshot From 2025-05-24 23-21-02](https://github.com/user-attachments/assets/d0394407-c42e-40de-8d61-bc1c761ebadb)
