### PR TITLE
Close window with gtk_window_destroy() instead of gtk_window_close()

### DIFF
--- a/src/pins-window.c
+++ b/src/pins-window.c
@@ -183,7 +183,7 @@ pins_window_close_request_cb (PinsWindow *self, gpointer user_data)
     if (g_strcmp0 (current_page_tag, pages[PAGE_FILE]) == 0)
         pins_window_save_current_desktop_file (self);
 
-    gtk_window_close (GTK_WINDOW (self));
+    gtk_window_destroy (GTK_WINDOW (self));
 }
 
 void


### PR DESCRIPTION
gtk_window_close() doesn't work on aarch64 systems. I've [filed](https://gitlab.gnome.org/GNOME/gtk/-/issues/7638) a bug against GTK, but until then, this'll work as a workaround.

(I have an aarch64 system, so I can confirm this works).

Closes #69