### PR TITLE
Change "Show Menu" tooltip to "Main Menu"

### DIFF
--- a/src/pins-app-view.ui
+++ b/src/pins-app-view.ui
@@ -23,7 +23,7 @@
                 </property>
                 <child type="end">
                   <object class="GtkMenuButton" id="menu_button">
-                    <property name="tooltip-text" translatable="yes">Show Menu</property>
+                    <property name="tooltip-text" translatable="yes">Main Menu</property>
                     <property name="icon-name">open-menu-symbolic</property>
                     <property name="menu-model">primary_menu</property>
                   </object>


### PR DESCRIPTION
This is to comply with GNOME's Human Interface Guidelines ([link](https://developer.gnome.org/hig/patterns/controls/menus.html#primary-menus)). A small thing I missed in my previous tooltip PR.